### PR TITLE
feat: bluetooth 監視スクリプトの初期実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.env
 config/local_device_config.json
 config/runtime_status.json
 *.log
+.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 config.env
 config/local_device_config.json
 config/runtime_status.json
+config/last_reboot_requested_at.txt
 *.log
 .claude/skills/
+venv/

--- a/bluetooth/device_watcher.py
+++ b/bluetooth/device_watcher.py
@@ -1,0 +1,65 @@
+import subprocess
+import urllib.request
+import json
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+CONFIG_FILE = REPO_ROOT / "config" / "local_device_config.json"
+CHECK_INTERVAL = 10  # チェック間隔（秒）
+
+
+def read_config():
+    if not CONFIG_FILE.exists():
+        raise FileNotFoundError(f"Config file not found: {CONFIG_FILE}")
+    with open(CONFIG_FILE) as f:
+        return json.load(f)
+
+
+_config = read_config()
+DEVICE_MAC = _config["bluetooth"]["device_mac"]
+SLACK_URL = _config["notification"]["slack"]["webhook_url"]
+
+def send_slack(message):
+    payload = json.dumps({"text": message}).encode("utf-8")
+    req = urllib.request.Request(SLACK_URL, data=payload, headers={"Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(req)
+    except Exception as e:
+        print(f"Slack送信失敗: {e}")
+
+def is_connected():
+    """bluetoothctlを使用して接続状態を確認する"""
+    cmd = f"bluetoothctl info {DEVICE_MAC}"
+    result = subprocess.run(cmd.split(), capture_output=True, text=True)
+    return "Connected: yes" in result.stdout
+
+DISCONNECT_DELAY = 60  # 切断通知を送るまでの猶予時間（秒）
+
+def main():
+    print("監視を開始します...")
+    last_state = is_connected() # 初期状態を取得
+
+    while True:
+        current_state = is_connected()
+
+        if current_state != last_state:
+            if current_state:
+                send_slack("🏠 【帰宅検知】スマホがBluetoothに接続されました。")
+                last_state = current_state
+            else:
+                # 切断検知: 60秒間様子を見て、まだ切断中なら通知する
+                print(f"切断を検知。{DISCONNECT_DELAY}秒後に確認します...")
+                time.sleep(DISCONNECT_DELAY)
+                if not is_connected():
+                    send_slack("🚪 【外出検知】スマホの接続が切れました。")
+                    last_state = False
+                else:
+                    print("瞬断と判断。通知をスキップします。")
+                    last_state = True
+                continue
+
+        time.sleep(CHECK_INTERVAL)
+
+if __name__ == "__main__":
+    main()

--- a/bluetooth/slack_bot.py
+++ b/bluetooth/slack_bot.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+REPO_ROOT = Path(__file__).parent.parent
+CONFIG_FILE = REPO_ROOT / "config" / "local_device_config.json"
+
+
+def read_config():
+    if not CONFIG_FILE.exists():
+        raise FileNotFoundError(f"Config file not found: {CONFIG_FILE}")
+    with open(CONFIG_FILE) as f:
+        return json.load(f)
+
+
+_config = read_config()
+_slack_config = _config["bluetooth"]["slack"]
+
+SLACK_BOT_TOKEN = _slack_config["bot_token"]
+SLACK_APP_TOKEN = _slack_config["app_token"]
+ALLOWED_USER_IDS = _config["bluetooth"]["allowed_user_ids"]
+
+app = App(token=SLACK_BOT_TOKEN)
+
+
+# ボットへのメンション（@ボット名）に反応する処理
+@app.event("app_mention")
+def handle_mention(event, say):
+    user_id = event.get("user")
+    if user_id not in ALLOWED_USER_IDS:
+        say(f"<@{user_id}> 申し訳ありません、あなたはこのボットを操作する権限がありません。")
+        return
+
+    text = event.get("text")
+
+    if "プラグオン" in text:
+        # ここにスマートプラグをONにするコードを書く
+        say("了解！スマートプラグをONにしました。")
+
+    elif "プラグオフ" in text:
+        # ここにスマートプラグをOFFにするコードを書く
+        say("了解！スマートプラグをOFFにしました。")
+
+    elif "状態" in text:
+        # Bluetooth接続の確認など、現在の状態を返す
+        say("現在は[在宅]モードで動作中です。")
+
+    else:
+        say("「プラグオン」「プラグオフ」「状態」のいずれかを送ってください。")
+
+if __name__ == "__main__":
+    # ソケットモードで起動
+    handler = SocketModeHandler(app, SLACK_APP_TOKEN)
+    handler.start()

--- a/config/local_device_config.example.json
+++ b/config/local_device_config.example.json
@@ -1,0 +1,53 @@
+{
+  "name": "開発マシンzero2",
+  "enabled": true,
+  "test_mode": true,
+  "expires": "2026-11-30T23:59:59+09:00",
+  "no_motion_hours": 8,
+  "heartbeat_grace_minutes": 150,
+  "cpu_temp_threshold": 70,
+  "exclude_periods": [
+    {
+      "from": "2025-10-13",
+      "to": "2025-10-13"
+    }
+  ],
+  "check_weekdays": [0, 1, 2, 3, 4],
+  "resumption_notifier": {
+    "enabled": true,
+    "trigger_hours": -4
+  },
+  "activity_report": {
+    "enabled": true,
+    "report_hours": 12,
+    "schedule_times": ["09:00", "21:00"],
+    "timezone": "Asia/Tokyo",
+    "min_motion_count": 0,
+    "include_no_activity_alert": true,
+    "report_type": "summary",
+    "report_weekdays": [0, 1, 2, 3, 4, 5, 6],
+    "destinations": [
+      {
+        "email": "example@example.com",
+        "notification_type": "min_motion_count",
+        "min_motion_count": 30
+      }
+    ]
+  },
+  "reboot": {
+    "requested_at": "2026-01-13T12:00:00+09:00"
+  },
+  "notification": {
+    "slack": {
+      "webhook_url": "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  },
+  "bluetooth": {
+    "device_mac": "XX:XX:XX:XX:XX:XX"
+  },
+  "env": "development",
+  "settings": {
+    "sensitivity": "low"
+  },
+  "device_id": "dev-zero-2"
+}


### PR DESCRIPTION
- requests を標準ライブラリ (urllib.request) に置き換え
- 切断検知時に 60 秒の猶予を設け、瞬断による誤通知を防止
- DEVICE_MAC・SLACK_URL を local_device_config.json から読み込むように変更